### PR TITLE
Fix helper bug and add coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Excel::queue(
 
 ---
 
-### 📚 FilamentBase
+### 📚 Filament Base
 
 ### 🔌 Creating a Modular Filament Plugin
 

--- a/src/Helpers/StringHelpers.php
+++ b/src/Helpers/StringHelpers.php
@@ -65,8 +65,14 @@ class StringHelpers
      */
     public static function normalizeString(?string $value): string
     {
+        $sanitized = self::sanitizeSpecialCharacters($value ?? '');
+
+        if ($sanitized === null) {
+            return '';
+        }
+
         return strtolower(
-            preg_replace('/\s+/', '', self::sanitizeSpecialCharacters($value ?? ''))
+            preg_replace('/\s+/', '', $sanitized)
         );
     }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use ZephyrIt\Shared\Helpers\ArrayHelpers;
+use ZephyrIt\Shared\Helpers\StringHelpers;
+use ZephyrIt\Shared\Helpers\FormatHelpers;
+
+it('flattens nested arrays using dot notation', function () {
+    $input = ['a' => ['b' => 1, 'c' => ['d' => 2]]];
+    $expected = ['a.b' => 1, 'a.c.d' => 2];
+
+    expect(ArrayHelpers::flattenArray($input))->toBe($expected);
+});
+
+it('normalizes strings safely', function () {
+    expect(StringHelpers::normalizeString(null))->toBe('');
+    expect(StringHelpers::normalizeString(' Foo Bar '))->toBe('foobar');
+});
+
+it('formats numbers into Indian format', function () {
+    expect(FormatHelpers::numberToIndianFormat(1234567))->toBe('12,34,567');
+});


### PR DESCRIPTION
## Summary
- fix `normalizeString` to handle null safely
- adjust heading typo in README
- add unit tests for helper methods

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a1e574888331aedb5a1abf30d969