### PR TITLE
Expand helper tests for edge cases

### DIFF
--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -19,3 +19,26 @@ it('normalizes strings safely', function () {
 it('formats numbers into Indian format', function () {
     expect(FormatHelpers::numberToIndianFormat(1234567))->toBe('12,34,567');
 });
+
+it('formats negative and decimal numbers into Indian format', function () {
+    expect(FormatHelpers::numberToIndianFormat(-1234567))->toBe('-12,34,567');
+    expect(FormatHelpers::numberToIndianFormat(1234567.89))->toBe('12,34,567.89');
+});
+
+it('shortens numbers near unit boundaries', function () {
+    expect(FormatHelpers::formatNumberShort(999))->toBe('999');
+    expect(FormatHelpers::formatNumberShort(1000))->toBe('1K');
+    expect(FormatHelpers::formatNumberShort(1500000))->toBe('1.5M');
+});
+
+it('sanitizes and formats strings correctly', function () {
+    expect(StringHelpers::sanitizeAndFormat('  jOhN DOE  '))->toBe('John Doe');
+    expect(StringHelpers::sanitizeAndFormat('  Mixed   CASE  ', true))->toBe('mixed case');
+    expect(StringHelpers::sanitizeAndFormat('  Multi   Words ', false, true))->toBe('MultiWords');
+});
+
+it('removes special characters from strings', function () {
+    expect(StringHelpers::sanitizeSpecialCharacters('Hello@World#'))->toBe('Hello World');
+    expect(StringHelpers::sanitizeSpecialCharacters('A-B=C', '-'))->toBe('A-B C');
+    expect(StringHelpers::sanitizeSpecialCharacters(null))->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add tests for `numberToIndianFormat` with negative and decimal values
- cover `formatNumberShort` near the unit thresholds
- test `sanitizeAndFormat` and `sanitizeSpecialCharacters` with varied inputs

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843a3d708048331a0a4ad0528fe126c