### PR TITLE
Improve exception handling and add date parser tests

### DIFF
--- a/src/Helpers/GeneratorHelpers.php
+++ b/src/Helpers/GeneratorHelpers.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace ZephyrIt\Shared\Helpers;
 
 use Carbon\Carbon;
-use Exception;
+use RuntimeException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Str;
@@ -56,7 +56,7 @@ class GeneratorHelpers
             usleep($retryDelay);
         }
 
-        throw new Exception('Unable to generate unique number after maximum retries.');
+        throw new RuntimeException('Unable to generate unique number after maximum retries.');
     }
 
     /**

--- a/src/Traits/HasDateRangeParser.php
+++ b/src/Traits/HasDateRangeParser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace ZephyrIt\Shared\Traits;
 
 use Carbon\Carbon;
-use Exception;
+use InvalidArgumentException;
 
 trait HasDateRangeParser
 {
@@ -19,7 +19,7 @@ trait HasDateRangeParser
         } elseif (is_string($dateFilter) && str_contains($dateFilter, ' - ')) {
             [$startDate, $endDate] = explode(' - ', $dateFilter);
         } else {
-            throw new Exception('Invalid date filter format.');
+            throw new InvalidArgumentException('The provided date range is invalid.');
         }
 
         return [
@@ -60,6 +60,6 @@ trait HasDateRangeParser
             return Carbon::createFromFormat('d/m/Y', $date);
         }
 
-        throw new Exception("Unsupported date format: {$date}");
+        throw new InvalidArgumentException("Unsupported date format: {$date}");
     }
 }

--- a/tests/Traits/HasDateRangeParserTest.php
+++ b/tests/Traits/HasDateRangeParserTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Carbon\Carbon;
+use InvalidArgumentException;
+use ZephyrIt\Shared\Traits\HasDateRangeParser;
+use ZephyrIt\Shared\Tests\TestCase;
+
+class DateRangeParserStub
+{
+    use HasDateRangeParser;
+}
+
+test('parses valid string date range', function () {
+    $stub = new DateRangeParserStub();
+    [$start, $end] = $stub->parseDateRange('2024-01-01 - 2024-01-31');
+
+    expect($start)->toBeInstanceOf(Carbon::class)
+        ->and($start->toDateString())->toBe('2024-01-01')
+        ->and($end->toDateString())->toBe('2024-01-31');
+});
+
+test('throws exception for invalid date filter', function () {
+    $stub = new DateRangeParserStub();
+
+    expect(fn () => $stub->parseDateRange('invalid'))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('throws exception for unsupported date format', function () {
+    $stub = new DateRangeParserStub();
+
+    expect(fn () => $stub->parseDateRange('2024/01/01 - 2024/01/02'))
+        ->toThrow(InvalidArgumentException::class);
+});


### PR DESCRIPTION
## Summary
- use more specific exceptions for date parser
- use runtime exception in generator helper
- add tests for `HasDateRangeParser`

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a7a825d883318c9770c80ba09cf2